### PR TITLE
Support for uploading deb source packages to packagecloud

### DIFF
--- a/publish_python/upload/packagecloud.py
+++ b/publish_python/upload/packagecloud.py
@@ -24,7 +24,7 @@ def upload_packagecloud(*, artifacts, upload, config):
         destination = f'{repository}{version}'
         for artifact in artifacts:
             ext = os.path.splitext(artifact)[1]
-            if ext not in ('.deb', '.whl'):
+            if ext not in ('.deb', '.whl', '.dsc'):
                 continue
 
             basename = os.path.basename(artifact)

--- a/publish_python/upload/packagecloud.py
+++ b/publish_python/upload/packagecloud.py
@@ -24,7 +24,7 @@ def upload_packagecloud(*, artifacts, upload, config):
         destination = f'{repository}{version}'
         for artifact in artifacts:
             ext = os.path.splitext(artifact)[1]
-            if ext not in ('.deb', '.whl', '.dsc'):
+            if ext not in ('.deb', '.dsc', '.whl'):
                 continue
 
             basename = os.path.basename(artifact)


### PR DESCRIPTION
The PR adds support to upload source packages (.dsc) to packagecloud. According to the [packagecloud documentation](https://packagecloud.io/docs) the upload of Debian source packages is supported via the same `push` command applied to the other types of packages. ROS repositories will require source packages for new uploads in the near future, the PR should help  preparing colcon packagecloud for this situation.

I run the changes on `colcon-core` and see the push command in the dry run:
```bash
...

== Uploading artifacts to 'packagecloud' ...
-- Skip uploading package to packagecloud.io, pass --upload to actually upload artifacts

Existing packagecloud.io package differs from the artifact 'python3-colcon-core_0.6.1-1_all.deb'

$ package_cloud push dirk-thomas/colcon/ubuntu/xenial deb_dist/python3-colcon-core_0.6.1-1_all.deb
$ package_cloud push dirk-thomas/colcon/ubuntu/xenial deb_dist/python3-colcon-core_0.6.1-1.dsc

Existing packagecloud.io package differs from the artifact 'python3-colcon-core_0.6.1-1_all.deb'

$ package_cloud push dirk-thomas/colcon/ubuntu/bionic deb_dist/python3-colcon-core_0.6.1-1_all.deb
$ package_cloud push dirk-thomas/colcon/ubuntu/bionic deb_dist/python3-colcon-core_0.6.1-1.dsc

Existing packagecloud.io package differs from the artifact 'python3-colcon-core_0.6.1-1_all.deb'

$ package_cloud push dirk-thomas/colcon/ubuntu/focal deb_dist/python3-colcon-core_0.6.1-1_all.deb
$ package_cloud push dirk-thomas/colcon/ubuntu/focal deb_dist/python3-colcon-core_0.6.1-1.dsc

Existing packagecloud.io package differs from the artifact 'python3-colcon-core_0.6.1-1_all.deb'

$ package_cloud push dirk-thomas/colcon/debian/stretch deb_dist/python3-colcon-core_0.6.1-1_all.deb
$ package_cloud push dirk-thomas/colcon/debian/stretch deb_dist/python3-colcon-core_0.6.1-1.dsc

Existing packagecloud.io package differs from the artifact 'python3-colcon-core_0.6.1-1_all.deb'

$ package_cloud push dirk-thomas/colcon/debian/buster deb_dist/python3-colcon-core_0.6.1-1_all.deb
$ package_cloud push dirk-thomas/colcon/debian/buster deb_dist/python3-colcon-core_0.6.1-1.dsc
```

 