### PR TITLE
Stop signing artifacts uploaded to PyPI

### DIFF
--- a/publish_python/upload/pypi.py
+++ b/publish_python/upload/pypi.py
@@ -10,7 +10,7 @@ def upload_pypi(*, artifacts, upload, config):
     else:
         print('-- Skip uploading package to PyPI, pass --upload to actually '
               'upload artifacts')
-    cmd = ['twine', 'upload', '-s', *artifacts]
+    cmd = ['twine', 'upload', *artifacts]
     print('$', *cmd)
     if upload:
         subprocess.check_call(cmd)


### PR DESCRIPTION
PGP signatures are now ignored when uploading artifacts to PyPI.

More information here: https://blog.pypi.org/posts/2023-05-23-removing-pgp/