### PR TITLE
Derive package name from setuptools fullname

### DIFF
--- a/publish_python/package.py
+++ b/publish_python/package.py
@@ -14,8 +14,11 @@ def get_package_name_and_version():
         raise RuntimeError(
             "Must be invoked in a directory containing a 'setup.py' file")
     output = subprocess.check_output(
-        [sys.executable, 'setup.py', '--name', '--version'])
+        [sys.executable, 'setup.py', '--fullname', '--version'])
     lines = output.decode('ascii').splitlines()
     assert len(lines) == 2
     Package = namedtuple('Package', ['name', 'version'])
-    return Package(lines[0], lines[1])
+    fullname = lines[0]
+    version = lines[1]
+    name = fullname[:-len(version) - 1]
+    return Package(name, version)


### PR DESCRIPTION
The value given by --name is the verbatim package name, while the --fullname yields the normalized package name used by setuptools followed by the version.

We can trim off the version part to get the normalized name so that the proper package name is used when looking for the archives produced by the wheel build process.